### PR TITLE
'learn_light' to 'learn_lighting' in spot_fixlight.json.

### DIFF
--- a/configs/spot_fixlight.json
+++ b/configs/spot_fixlight.json
@@ -11,6 +11,6 @@
     "envmap": "data/irrmaps/aerodynamics_workshop_2k.hdr",
     "background": "white",
     "validate" : false,
-    "learn_light" : false,
+    "learn_lighting" : false,
     "out_dir": "spot"
 }


### PR DESCRIPTION
The item `learn_light` should be `learn_lighting` in `spot_fixlight.json`, as defined in `train.py`:

```python
    FLAGS.learn_lighting      = True        # Enable optimization of env lighting
```